### PR TITLE
Fix blog image path normalization

### DIFF
--- a/blog-details.php
+++ b/blog-details.php
@@ -88,17 +88,29 @@ function resolve_blog_image_path(?string $path, string $default): string
         return $path;
     }
 
-    $normalized = ltrim($path, '/');
-    if (strpos($normalized, './') === 0) {
-        $normalized = substr($normalized, 2);
+    $normalized = str_replace('\\', '/', $path);
+    $normalized = preg_replace('#^(?:\./)+#', '', $normalized);
+    $normalized = ltrim((string)$normalized, '/');
+
+    if ($normalized === '') {
+        return $default;
     }
 
     $uploadBase = 'admin/assets/uploads/';
-    if (strpos($normalized, $uploadBase) !== 0) {
-        $normalized = $uploadBase . $normalized;
+
+    if (strpos($normalized, $uploadBase) === 0) {
+        return $normalized;
     }
 
-    return $normalized;
+    if (strpos($normalized, 'assets/uploads/') === 0) {
+        return 'admin/' . $normalized;
+    }
+
+    if (strpos($normalized, 'uploads/') === 0) {
+        return 'admin/assets/' . $normalized;
+    }
+
+    return $uploadBase . $normalized;
 }
 
 function format_heading_with_span(string $heading): string

--- a/blogs.php
+++ b/blogs.php
@@ -121,17 +121,29 @@ function resolve_blog_image_path(?string $path, string $default): string
         return $path;
     }
 
-    $normalized = ltrim($path, '/');
-    if (strpos($normalized, './') === 0) {
-        $normalized = substr($normalized, 2);
+    $normalized = str_replace('\\', '/', $path);
+    $normalized = preg_replace('#^(?:\./)+#', '', $normalized);
+    $normalized = ltrim((string)$normalized, '/');
+
+    if ($normalized === '') {
+        return $default;
     }
 
     $uploadBase = 'admin/assets/uploads/';
-    if (strpos($normalized, $uploadBase) !== 0) {
-        $normalized = $uploadBase . $normalized;
+
+    if (strpos($normalized, $uploadBase) === 0) {
+        return $normalized;
     }
 
-    return $normalized;
+    if (strpos($normalized, 'assets/uploads/') === 0) {
+        return 'admin/' . $normalized;
+    }
+
+    if (strpos($normalized, 'uploads/') === 0) {
+        return 'admin/assets/' . $normalized;
+    }
+
+    return $uploadBase . $normalized;
 }
 
 function build_blog_page_url(int $page): string


### PR DESCRIPTION
## Summary
- normalize stored blog image paths so existing uploads resolve correctly on listing and detail pages

## Testing
- php -l blogs.php
- php -l blog-details.php

------
https://chatgpt.com/codex/tasks/task_e_68d183c9c758832abe610138823e52cf