### PR TITLE
Add reCAPTCHA validation and international phone inputs to mortgage forms

### DIFF
--- a/mortgage/includes/common-footer.php
+++ b/mortgage/includes/common-footer.php
@@ -32,6 +32,8 @@
 <!-- Bootstrap JS CDN -->
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/18.2.1/js/intlTelInput.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/18.2.1/js/utils.min.js"></script>
 <!-- jQuery CDN required for AJAX -->
 
 

--- a/mortgage/includes/common-header.php
+++ b/mortgage/includes/common-header.php
@@ -17,6 +17,8 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="assets/css/style.css">
     <link rel="stylesheet" href="assets/css/responsive.css">
+    <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/18.2.1/css/intlTelInput.css" />
 
     <!-- Google Tag Manager -->
     <script>


### PR DESCRIPTION
## Summary
- add backend handling for the mortgage lead forms to validate reCAPTCHA, persist submissions, and redirect to the thank-you page
- integrate Google reCAPTCHA widgets and intl-tel-input phone fields into both hero and footer forms with proper error messaging
- include the intl-tel-input assets and initialize the controls so country codes and full numbers are captured before saving

## Testing
- php -l mortgage/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d8f16c1054832aa1c6754d596a2265