### PR TITLE
Add mortgage leads admin view

### DIFF
--- a/admin/includes/render.php
+++ b/admin/includes/render.php
@@ -37,6 +37,7 @@ function render_sidebar(string $active): void
     'logs'      => ['href' => 'page_access_logs.php', 'icon' => 'bi-universal-access-circle',       'label' => 'Page Access Logs'],
     'analytics' => ['href' => 'analytics_dashboard.php', 'icon' => 'bi-graph-up-arrow', 'label' => 'Analytics Dashboard'],
     'contact-form' => ['href' => 'contact_form_submissions.php', 'icon' => 'bi-person-rolodex', 'label' => 'Contact Submissions'],
+    'mortgage-leads' => ['href' => 'mortgage_leads.php', 'icon' => 'bi-cash-coin', 'label' => 'Mortgage Leads'],
     'popup-form' => ['href' => 'popup_form_submissions.php', 'icon' => 'bi-database', 'label' => 'Popup Submissions'],
     'add-property' => ['href' => 'add_property.php', 'icon' => 'bi-buildings', 'label' => 'Add Property'],
     'add-blogs' => ['href' => 'add_blogs.php', 'icon' => 'bi-journal-plus', 'label' => 'Add Blogs'],

--- a/admin/mortgage_leads.php
+++ b/admin/mortgage_leads.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+require_once __DIR__ . '/includes/render.php';
+require_once __DIR__ . '/includes/auth.php';
+
+process_logout();
+
+if (!is_authenticated()) {
+  header('Location: login.php');
+  exit;
+}
+
+$pdo = db();
+$perPage = 10;
+$page = filter_input(
+  INPUT_GET,
+  'page',
+  FILTER_VALIDATE_INT,
+  ['options' => ['default' => 1, 'min_range' => 1]]
+);
+$offset = ($page - 1) * $perPage;
+$totalRecords = 0;
+$totalPages = 0;
+$leads = [];
+$error = null;
+
+try {
+  $countStmt = $pdo->query('SELECT COUNT(*) FROM mortgage_leads');
+  $totalRecords = (int) $countStmt->fetchColumn();
+
+  if ($totalRecords > 0) {
+    $totalPages = (int) ceil($totalRecords / $perPage);
+    if ($page > $totalPages) {
+      $page = $totalPages;
+      $offset = ($page - 1) * $perPage;
+    }
+
+    $stmt = $pdo->prepare(
+      'SELECT id, name, email, phone, location, created_at '
+      . 'FROM mortgage_leads ORDER BY created_at DESC, id DESC '
+      . 'LIMIT :limit OFFSET :offset'
+    );
+    $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+    $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+    $stmt->execute();
+    $leads = $stmt->fetchAll();
+  } else {
+    $page = 1;
+    $offset = 0;
+  }
+} catch (Throwable $e) {
+  error_log('Failed to load mortgage leads: ' . $e->getMessage());
+  $error = 'Unable to load mortgage leads at this time.';
+}
+
+$paginationBasePath = strtok((string) ($_SERVER['REQUEST_URI'] ?? ''), '?') ?: '/mortgage_leads.php';
+$paginationQueryParams = $_GET;
+unset($paginationQueryParams['page']);
+$buildPaginationUrl = static function (int $targetPage) use ($paginationBasePath, $paginationQueryParams): string {
+  $params = $paginationQueryParams;
+  $params['page'] = $targetPage;
+  $queryString = http_build_query($params);
+  $url = $paginationBasePath . ($queryString ? '?' . $queryString : '');
+  return $url === '' ? '#' : $url;
+};
+
+render_head('Mortgage Leads');
+echo '<div class="container-fluid layout">';
+echo '<div class="row g-0">';
+render_sidebar('mortgage-leads');
+?>
+<main class="col-12 col-md-9 col-lg-10 content">
+  <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
+    <div>
+      <h2 class="title-heading">Mortgage Leads</h2>
+      <p class="para mb-0">Review submissions from the mortgage leads table.</p>
+    </div>
+    <div class="text-lg-end">
+      <span class="badge bg-primary-subtle text-primary fw-semibold">Total leads: <?= number_format($totalRecords) ?></span>
+    </div>
+  </div>
+
+  <?php if ($error): ?>
+    <div class="alert alert-warning" role="alert">
+      <?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?>
+    </div>
+  <?php elseif (!$leads): ?>
+    <div class="alert alert-info" role="alert">
+      No mortgage leads found.
+    </div>
+  <?php else: ?>
+    <div class="box">
+      <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle mb-0">
+          <thead class="table-secondary">
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">Name</th>
+              <th scope="col">Email</th>
+              <th scope="col">Phone</th>
+              <th scope="col">Location</th>
+              <th scope="col">Submitted</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($leads as $lead): ?>
+              <tr>
+                <td><?= (int) $lead['id'] ?></td>
+                <td><?= htmlspecialchars((string) ($lead['name'] ?? ''), ENT_QUOTES, 'UTF-8') ?></td>
+                <td>
+                  <?php if (!empty($lead['email'])): ?>
+                    <a href="mailto:<?= htmlspecialchars($lead['email'], ENT_QUOTES, 'UTF-8') ?>">
+                      <?= htmlspecialchars($lead['email'], ENT_QUOTES, 'UTF-8') ?>
+                    </a>
+                  <?php else: ?>
+                    <span class="text-muted">—</span>
+                  <?php endif; ?>
+                </td>
+                <td><?= htmlspecialchars((string) ($lead['phone'] ?? '—'), ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars((string) ($lead['location'] ?? '—'), ENT_QUOTES, 'UTF-8') ?></td>
+                <td>
+                  <?php
+                  $createdAt = (string) ($lead['created_at'] ?? '');
+                  if ($createdAt !== '') {
+                    $dt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $createdAt);
+                    echo htmlspecialchars($dt ? $dt->format('d M Y, H:i') : $createdAt, ENT_QUOTES, 'UTF-8');
+                  } else {
+                    echo '<span class="text-muted">—</span>';
+                  }
+                  ?>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+      <?php if ($totalPages > 1): ?>
+        <nav aria-label="Mortgage leads pagination" class="mt-3">
+          <ul class="pagination mb-0">
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+              <?php if ($page <= 1): ?>
+                <span class="page-link">Previous</span>
+              <?php else: ?>
+                <a class="page-link" href="<?= htmlspecialchars($buildPaginationUrl($page - 1), ENT_QUOTES, 'UTF-8') ?>" aria-label="Previous">Previous</a>
+              <?php endif; ?>
+            </li>
+            <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+              <li class="page-item<?= $i === $page ? ' active' : '' ?>"<?php if ($i === $page): ?> aria-current="page"<?php endif; ?>>
+                <?php if ($i === $page): ?>
+                  <span class="page-link"><?= $i ?></span>
+                <?php else: ?>
+                  <a class="page-link" href="<?= htmlspecialchars($buildPaginationUrl($i), ENT_QUOTES, 'UTF-8') ?>"><?= $i ?></a>
+                <?php endif; ?>
+              </li>
+            <?php endfor; ?>
+            <li class="page-item<?= $page >= $totalPages ? ' disabled' : '' ?>">
+              <?php if ($page >= $totalPages): ?>
+                <span class="page-link">Next</span>
+              <?php else: ?>
+                <a class="page-link" href="<?= htmlspecialchars($buildPaginationUrl($page + 1), ENT_QUOTES, 'UTF-8') ?>" aria-label="Next">Next</a>
+              <?php endif; ?>
+            </li>
+          </ul>
+        </nav>
+      <?php endif; ?>
+    </div>
+  <?php endif; ?>
+</main>
+<?php
+echo '</div>';
+echo '</div>';
+render_footer();


### PR DESCRIPTION
## Summary
- add an authenticated admin page to list mortgage leads with a Bootstrap table and 10-item pagination
- wire the new mortgage leads page into the admin sidebar navigation

## Testing
- php -l admin/mortgage_leads.php
- php -l admin/includes/render.php

------
https://chatgpt.com/codex/tasks/task_e_68d909e82f10832a8cbaeeba14f1f998