### PR TITLE
Fix image normalization for property uploads

### DIFF
--- a/offplan-properties.php
+++ b/offplan-properties.php
@@ -15,7 +15,8 @@ $propertyCount = count($offplanProperties);
 $updatedLabel = date('F j, Y');
 
 $uploadsBasePath = 'admin/assets/uploads/properties/';
-$normalizeImagePath = static function (?string $path) use ($uploadsBasePath): ?string {
+$legacyUploadsPrefix = 'assets/uploads/properties/';
+$normalizeImagePath = static function (?string $path) use ($uploadsBasePath, $legacyUploadsPrefix): ?string {
     if (!is_string($path)) {
         return null;
     }
@@ -30,8 +31,13 @@ $normalizeImagePath = static function (?string $path) use ($uploadsBasePath): ?s
     }
 
     $path = ltrim($path, '/');
+
     if (str_starts_with($path, $uploadsBasePath)) {
         return $path;
+    }
+
+    if (str_starts_with($path, $legacyUploadsPrefix)) {
+        return $uploadsBasePath . substr($path, strlen($legacyUploadsPrefix));
     }
 
     return $uploadsBasePath . $path;

--- a/property-details.php
+++ b/property-details.php
@@ -48,7 +48,8 @@ $decodeList = static function (?string $json): array {
 };
 
 $uploadsBasePath = 'admin/assets/uploads/properties/';
-$normalizeImagePath = static function (?string $path) use ($uploadsBasePath): ?string {
+$legacyUploadsPrefix = 'assets/uploads/properties/';
+$normalizeImagePath = static function (?string $path) use ($uploadsBasePath, $legacyUploadsPrefix): ?string {
     if (!is_string($path)) {
         return null;
     }
@@ -63,8 +64,13 @@ $normalizeImagePath = static function (?string $path) use ($uploadsBasePath): ?s
     }
 
     $path = ltrim($path, '/');
+
     if (str_starts_with($path, $uploadsBasePath)) {
         return $path;
+    }
+
+    if (str_starts_with($path, $legacyUploadsPrefix)) {
+        return $uploadsBasePath . substr($path, strlen($legacyUploadsPrefix));
     }
 
     return $uploadsBasePath . $path;


### PR DESCRIPTION
## Summary
- handle legacy property asset paths that omit the admin directory so images resolve correctly
- apply the same path normalization when rendering the off-plan listings

## Testing
- php -l property-details.php
- php -l offplan-properties.php

------
https://chatgpt.com/codex/tasks/task_e_68da39dee5f4832ab7a8b3067dd2c67d