### PR TITLE
Restore HTML content in admin rich text editors

### DIFF
--- a/admin/add_blogs.php
+++ b/admin/add_blogs.php
@@ -482,7 +482,7 @@ render_sidebar('add-blogs');
       </div>
       <div class="col-12">
         <label for="content" class="form-label">Text Editor for Blog Details Page</label>
-        <textarea class="form-control" id="content" name="content" rows="10" required><?= htmlspecialchars($content, ENT_QUOTES, 'UTF-8') ?></textarea>
+        <textarea class="form-control" id="content" name="content" rows="10" required><?= admin_editor_content($content) ?></textarea>
         <div class="form-text">Use the editor to format headings, links, images, and more.</div>
       </div>
       <div class="col-12">

--- a/admin/add_job_vacancy.php
+++ b/admin/add_job_vacancy.php
@@ -325,7 +325,7 @@ render_sidebar('add-job-vacancy');
       </div>
       <div class="col-12">
         <label for="job_description" class="form-label">Job Description</label>
-        <textarea class="form-control" id="job_description" name="job_description" rows="10" required><?= htmlspecialchars($jobDescription, ENT_QUOTES, 'UTF-8') ?></textarea>
+        <textarea class="form-control" id="job_description" name="job_description" rows="10" required><?= admin_editor_content($jobDescription) ?></textarea>
         <div class="form-text">Use the rich text editor to format the job description.</div>
       </div>
       <div class="col-12">

--- a/admin/add_property.php
+++ b/admin/add_property.php
@@ -1214,7 +1214,7 @@ render_sidebar('add-property');
             </div>
             <div class="col-12">
               <label for="about_project" class="form-label">About Project (Overview In Rich Text Editor)</label>
-              <textarea class="form-control" id="about_project" name="about_project" rows="6" placeholder="Enter an engaging project overview..."><?= htmlspecialchars($formData['about_project'], ENT_QUOTES, 'UTF-8') ?></textarea>
+              <textarea class="form-control" id="about_project" name="about_project" rows="6" placeholder="Enter an engaging project overview..."><?= admin_editor_content($formData['about_project']) ?></textarea>
             </div>
           </div>
         </section>

--- a/admin/includes/bootstrap.php
+++ b/admin/includes/bootstrap.php
@@ -153,3 +153,23 @@ function respond_json(array $payload, int $status = 200): void
   echo json_encode($payload, JSON_UNESCAPED_UNICODE);
   exit;
 }
+
+/**
+ * Prepare previously saved rich text editor content for use inside a textarea.
+ *
+ * CKEditor expects real HTML markup when initialising from a textarea. Earlier we
+ * escaped the content with htmlspecialchars(), which converted the markup into
+ * plain text (e.g. "<p>"). By returning the raw HTML we allow the editor to
+ * restore the formatted content while still protecting the surrounding
+ * <textarea> element from being prematurely closed.
+ */
+function admin_editor_content(string $value): string
+{
+  if ($value === '') {
+    return '';
+  }
+
+  // Prevent any embedded closing textarea tag from breaking the markup while
+  // keeping the rest of the HTML intact for the editor to render.
+  return str_ireplace('</textarea', '&lt;/textarea', $value);
+}

--- a/admin/market_reports.php
+++ b/admin/market_reports.php
@@ -358,7 +358,7 @@ render_sidebar('market-reports');
             id="short_description"
             name="short_description"
             rows="4"
-            required><?= htmlspecialchars($shortDescription, ENT_QUOTES, 'UTF-8') ?></textarea>
+            required><?= admin_editor_content($shortDescription) ?></textarea>
           <div class="form-text">Provide a concise overview of the report to help users understand its focus.</div>
         </div>
 
@@ -369,7 +369,7 @@ render_sidebar('market-reports');
             id="long_description"
             name="long_description"
             rows="6"
-            required><?= htmlspecialchars($longDescription, ENT_QUOTES, 'UTF-8') ?></textarea>
+            required><?= admin_editor_content($longDescription) ?></textarea>
           <div class="form-text">Provide detailed insights, methodology, and supporting data for the report.</div>
         </div>
 
@@ -415,7 +415,7 @@ render_sidebar('market-reports');
             id="mockup_description"
             name="mockup_description"
             rows="4"
-            required><?= htmlspecialchars($mockupDescription, ENT_QUOTES, 'UTF-8') ?></textarea>
+            required><?= admin_editor_content($mockupDescription) ?></textarea>
         </div>
 
         <div class="col-md-6">


### PR DESCRIPTION
## Summary
- add a helper to safely inject saved HTML into admin rich-text editor textareas
- update blog, property, job vacancy, and market report forms to use the helper so CKEditor loads formatted content

## Testing
- php -l admin/includes/bootstrap.php
- php -l admin/add_blogs.php
- php -l admin/add_job_vacancy.php
- php -l admin/add_property.php
- php -l admin/market_reports.php

------
https://chatgpt.com/codex/tasks/task_e_68db75e55158832a9f75c9516adbe859