### PR TITLE
Update admin rich text editor configuration

### DIFF
--- a/admin/add_blogs.php
+++ b/admin/add_blogs.php
@@ -500,7 +500,7 @@ render_sidebar('add-blogs');
 echo '</div>';
 echo '</div>';
 ?>
-<script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/super-build/ckeditor.js"></script>
+<script src="https://cdn.ckeditor.com/ckeditor5/41.3.1/super-build/ckeditor.js"></script>
 <script>
   (function() {
     const textarea = document.querySelector('#content');
@@ -561,7 +561,20 @@ echo '</div>';
       fontBackgroundColor: {
         columns: 5,
         documentColors: 10
-      }
+      },
+      removePlugins: [
+        'CKBox',
+        'CKFinder',
+        'EasyImage',
+        'RealTimeCollaborativeComments',
+        'RealTimeCollaborativeTrackChanges',
+        'RealTimeCollaborativeRevisionHistory',
+        'PresenceList',
+        'Comments',
+        'TrackChanges',
+        'TrackChangesData',
+        'MathType'
+      ]
     };
     if (!textarea) {
       return;

--- a/admin/add_job_vacancy.php
+++ b/admin/add_job_vacancy.php
@@ -340,7 +340,7 @@ render_sidebar('add-job-vacancy');
 echo '</div>';
 echo '</div>';
 ?>
-<script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/super-build/ckeditor.js"></script>
+<script src="https://cdn.ckeditor.com/ckeditor5/41.3.1/super-build/ckeditor.js"></script>
 <script>
   (function() {
     const form = document.getElementById('add-job-vacancy-form');
@@ -403,7 +403,20 @@ echo '</div>';
       fontBackgroundColor: {
         columns: 5,
         documentColors: 10
-      }
+      },
+      removePlugins: [
+        'CKBox',
+        'CKFinder',
+        'EasyImage',
+        'RealTimeCollaborativeComments',
+        'RealTimeCollaborativeTrackChanges',
+        'RealTimeCollaborativeRevisionHistory',
+        'PresenceList',
+        'Comments',
+        'TrackChanges',
+        'TrackChangesData',
+        'MathType'
+      ]
     };
 
     if (successAlert) {

--- a/admin/add_property.php
+++ b/admin/add_property.php
@@ -1739,7 +1739,7 @@ render_sidebar('add-property');
     </form>
   </div>
 </main>
-<script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/super-build/ckeditor.js"></script>
+<script src="https://cdn.ckeditor.com/ckeditor5/41.3.1/super-build/ckeditor.js"></script>
 <script>
   (function() {
     const form = document.querySelector('.box form');
@@ -1801,7 +1801,20 @@ render_sidebar('add-property');
       fontBackgroundColor: {
         columns: 5,
         documentColors: 10
-      }
+      },
+      removePlugins: [
+        'CKBox',
+        'CKFinder',
+        'EasyImage',
+        'RealTimeCollaborativeComments',
+        'RealTimeCollaborativeTrackChanges',
+        'RealTimeCollaborativeRevisionHistory',
+        'PresenceList',
+        'Comments',
+        'TrackChanges',
+        'TrackChangesData',
+        'MathType'
+      ]
     };
 
     if (form) {

--- a/admin/includes/bootstrap.php
+++ b/admin/includes/bootstrap.php
@@ -25,7 +25,7 @@ if ($secureConn) {
   header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
 }
 header(
-  "Content-Security-Policy: default-src 'self' cdn.jsdelivr.net cdn.plot.ly; img-src 'self' data:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdn.plot.ly; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'"
+  "Content-Security-Policy: default-src 'self' cdn.jsdelivr.net cdn.plot.ly cdn.ckeditor.com; img-src 'self' data:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdn.ckeditor.com; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdn.plot.ly cdn.ckeditor.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'"
 );
 
 const ADMIN_USER = 'admin';

--- a/admin/market_reports.php
+++ b/admin/market_reports.php
@@ -448,7 +448,7 @@ render_sidebar('market-reports');
       </form>
     </div>
   </div>
-  <script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/super-build/ckeditor.js"></script>
+  <script src="https://cdn.ckeditor.com/ckeditor5/41.3.1/super-build/ckeditor.js"></script>
   <script>
     (() => {
       const form = document.getElementById('market-report-form');
@@ -509,7 +509,20 @@ render_sidebar('market-reports');
         fontBackgroundColor: {
           columns: 5,
           documentColors: 10
-        }
+        },
+        removePlugins: [
+          'CKBox',
+          'CKFinder',
+          'EasyImage',
+          'RealTimeCollaborativeComments',
+          'RealTimeCollaborativeTrackChanges',
+          'RealTimeCollaborativeRevisionHistory',
+          'PresenceList',
+          'Comments',
+          'TrackChanges',
+          'TrackChangesData',
+          'MathType'
+        ]
       };
 
       document.querySelectorAll('.alert[data-auto-dismiss]').forEach((alertEl) => {


### PR DESCRIPTION
## Summary
- upgrade the admin rich text editor CDN across the blog, job vacancy, property, and market report forms
- disable CKEditor premium/collaboration plugins that require external services to avoid runtime errors
- extend the admin content security policy to allow loading CKEditor assets from the official CDN

## Testing
- php -l admin/add_blogs.php
- php -l admin/add_job_vacancy.php
- php -l admin/add_property.php
- php -l admin/market_reports.php

------
https://chatgpt.com/codex/tasks/task_e_68db7878f494832a9ea73491832a5bec